### PR TITLE
Specify prettier@^2.3.0 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
 	},
 	"devDependencies": {
 		"prettier": "^2.3.0"
+	},
+	"peerDependencies": {
+		"prettier": "^2.3.0"
 	}
 }


### PR DESCRIPTION
As the printer uses `label`, which was [added in Prettier v2.3.0](https://github.com/prettier/prettier/blob/main/commands.md#label), this plugin is not compatible with earlier versions of Prettier. This should be declared to ensure a user is warned on install if their current version is incompatible.

This fixes #2.